### PR TITLE
🚇 Upload pdfs and evaluated notebooks as release assets

### DIFF
--- a/.github/workflows/build-pdfs.yml
+++ b/.github/workflows/build-pdfs.yml
@@ -58,3 +58,43 @@ jobs:
         with:
           name: pdfs
           path: pdfs/*.pdf
+
+      - name: Upload Evaluated Notebooks
+        uses: actions/upload-artifact@v3
+        with:
+          name: notebooks
+          path: ${{ matrix.case_study }}/*.ipynb
+
+  upload-artifacts:
+    name: 📦⬆️ Deploy assets to release page
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    permissions:
+      contents: write
+    needs: build
+    steps:
+      - name: ⬇ Download pdf artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: pdfs
+          path: pdfs
+
+      - name: ⬇ Download notebooks artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: notebooks
+          path: notebooks
+
+      - name: 🚀⬆️ Upload pdf Asset
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: pdfs/*
+
+      - name: 🚀⬆️ Upload notebooks Asset
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: notebooks/*
+          generate_release_notes: true
+          append_body: true


### PR DESCRIPTION
With this change the pdfs and evaluated notebooks are uploaded to the release page when a new release is created.

See [this test release](https://github.com/s-weigand/pub-2023-05-van_Stokkum_et_al/releases/tag/asset-upload-on-release-test) on my fork.

### Change summary

- [🚇 Upload pdfs and evaluated notebooks as release assets](https://github.com/glotaran/pub-2023-05-van_Stokkum_et_al/commit/248da5b17bae5a962dc91cf63c3729a7608bd186)


### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)